### PR TITLE
Suggest filenames without file

### DIFF
--- a/src/holo-build/main.go
+++ b/src/holo-build/main.go
@@ -41,9 +41,9 @@ type options struct {
 	withForce        bool
 }
 
-func main() {
-	opts := parseArgs()
+var opts = parseArgs()
 
+func main() {
 	//read package definition from stdin
 	input := io.Reader(os.Stdin)
 	baseDirectory := "."

--- a/src/holo-build/parser.go
+++ b/src/holo-build/parser.go
@@ -414,6 +414,9 @@ func parseFileContent(content string, contentFrom string, dontPruneIndent bool, 
 		//resolve relative paths
 		contentFrom = filepath.Join(baseDirectory, contentFrom)
 	}
+	if opts.filenameOnly {
+		return string("")
+	}
 	bytes, err := ioutil.ReadFile(contentFrom)
 	ec.Add(err)
 	return string(bytes)

--- a/test/interface/04-output-to-directory/expected-stdout
+++ b/test/interface/04-output-to-directory/expected-stdout
@@ -1,3 +1,3 @@
 checking existing output directory
-foo/bar/package_1.0-1_all.deb: Debian binary package (format 2.0)
+foo/bar/package_1.0-1_all.deb: Debian binary package (format 2.0), with control.tar.gz, data compression xz  
 checking missing output directory


### PR DESCRIPTION
I want to use the suggested filename in a Makefile before downloading the included files. This change allows to suggest filenames of packages without checking if the file actual exists.