### PR TITLE
Make holo-build.sh posix compliant

### DIFF
--- a/src/holo-build.sh
+++ b/src/holo-build.sh
@@ -28,7 +28,7 @@ for ARG in "$@"; do
 done
 
 # check distribution and choose appropriate package format
-[ -f /etc/os-release ] && source /etc/os-release || source /usr/lib/os-release
+[ -f /etc/os-release ] && . /etc/os-release || . /usr/lib/os-release
 DIST_IDS="$(echo "$ID $ID_LIKE" | tr ' ' ',')"
 
 case ",$DIST_IDS," in


### PR DESCRIPTION
This fixes the following error I got after using the source build:
```
/usr/bin/holo-build: 31: source: not found
/usr/bin/holo-build: 31: source: not found
```

Reason: In Ubuntu ``/bin/sh`` is symlinked to `dash` which does not understand `source` but only `.` syntax.

See https://github.com/koalaman/shellcheck/wiki/SC2039