### PR TITLE
support prerelease packages (alpha and beta)

### DIFF
--- a/doc/holo-build.8.pod
+++ b/doc/holo-build.8.pod
@@ -200,6 +200,22 @@ dots:
     version = "0.10"
     version = "20151015"
 
+=item B<prereleaseType> (string)
+
+The prerelease type. Valid values are:
+
+    none
+    alpha
+    beta
+
+"none" means that it's not a prerelease, but a final release.
+
+=item B<prereleaseNo> (unsigned integer)
+
+The prerelease number. Default value is 0. It must be changed for
+prerelease types other than "none". When prerelease type is "none",
+this must be 0.
+
 =item B<epoch> (unsigned integer)
 
 An increase in the epoch (default: 0) can be used to force the package to be

--- a/src/holo-build/parser.go
+++ b/src/holo-build/parser.go
@@ -53,6 +53,8 @@ type PackageDefinition struct {
 type PackageSection struct {
 	Name           string
 	Version        string
+	PrereleaseType string
+	PrereleaseNo   uint
 	Release        uint
 	Epoch          uint
 	Description    string
@@ -138,6 +140,13 @@ var archMap = map[string]build.Architecture{
 	//END ARCH
 }
 
+//map supported input strings for prerelease types to internal prerelease type enum
+var prerelTypeMap = map[string]build.PrereleaseType{
+	"none":  build.PrereleaseTypeNone,
+	"alpha": build.PrereleaseTypeAlpha,
+	"beta":  build.PrereleaseTypeBeta,
+}
+
 //ParsePackageDefinition parses a package definition from the given input.
 //The operation is successful if the returned []error is empty.
 func ParsePackageDefinition(input io.Reader, baseDirectory string) (*build.Package, []error) {
@@ -156,6 +165,7 @@ func ParsePackageDefinition(input io.Reader, baseDirectory string) (*build.Packa
 	pkg := build.Package{
 		Name:              strings.TrimSpace(p.Package.Name),
 		Version:           strings.TrimSpace(p.Package.Version),
+		PrereleaseNo:      p.Package.PrereleaseNo,
 		Release:           p.Package.Release,
 		Epoch:             p.Package.Epoch,
 		Description:       strings.TrimSpace(p.Package.Description),
@@ -165,6 +175,26 @@ func ParsePackageDefinition(input io.Reader, baseDirectory string) (*build.Packa
 		FSRoot:            filesystem.NewDirectory(),
 	}
 	pkg.FSRoot.Implicit = true
+
+	//parse prerelease type string
+	if p.Package.PrereleaseType != "" {
+		var ok bool
+		pkg.PrereleaseType, ok = prerelTypeMap[p.Package.PrereleaseType]
+		if !ok {
+			err := fmt.Errorf("Invalid prereleaseType \"%s\"", p.Package.PrereleaseType)
+			return nil, []error{err}
+		}
+	}
+
+	if pkg.PrereleaseType == build.PrereleaseTypeNone && pkg.PrereleaseNo != 0 {
+		err := fmt.Errorf("Invalid (nonzero) prereleaseNo (%d) for prereleaseType \"none\"", p.Package.PrereleaseNo)
+		return nil, []error{err}
+	}
+
+	if pkg.PrereleaseType != build.PrereleaseTypeNone && pkg.PrereleaseNo == 0 {
+		err := fmt.Errorf("Invalid prereleaseNo (0) for prereleaseType \"%s\" (not \"none\")", p.Package.PrereleaseType)
+		return nil, []error{err}
+	}
 
 	if script := strings.TrimSpace(p.Package.SetupScript); script != "" {
 		WarnDeprecatedKey("package.setupScript")

--- a/vendor/github.com/holocm/libpackagebuild/debian/generator.go
+++ b/vendor/github.com/holocm/libpackagebuild/debian/generator.go
@@ -89,11 +89,21 @@ func (g *Generator) Validate() []error {
 }
 
 func fullVersionString(pkg *build.Package) string {
-	str := fmt.Sprintf("%s-%d", pkg.Version, pkg.Release)
+	var b strings.Builder
+
 	if pkg.Epoch > 0 {
-		str = fmt.Sprintf("%d:%s", pkg.Epoch, str)
+		fmt.Fprintf(&b, "%d:", pkg.Epoch)
 	}
-	return str
+
+	b.WriteString(pkg.Version)
+
+	if pkg.PrereleaseType != build.PrereleaseTypeNone {
+		fmt.Fprintf(&b, "~%s.%d", pkg.PrereleaseType.ToString(), pkg.PrereleaseNo)
+	}
+
+	fmt.Fprintf(&b, "-%d", pkg.Release)
+
+	return b.String()
 }
 
 type arArchiveEntry struct {

--- a/vendor/github.com/holocm/libpackagebuild/package.go
+++ b/vendor/github.com/holocm/libpackagebuild/package.go
@@ -48,6 +48,27 @@ const (
 	ArchitectureAArch64
 )
 
+//PrerelaseType is an enum that describes whether the package is an alpha, beta or final release.
+type PrereleaseType uint
+
+const (
+	// Final release
+	PrereleaseTypeNone PrereleaseType = iota
+	// Alpha
+	PrereleaseTypeAlpha
+	// Beta
+	PrereleaseTypeBeta
+)
+
+func (pt PrereleaseType) ToString() string {
+	switch pt {
+	case PrereleaseTypeNone: return "none"
+	case PrereleaseTypeAlpha: return "alpha"
+	case PrereleaseTypeBeta: return "beta"
+	}
+    panic("unreachable")
+}
+
 //Package contains all information about a single package. This representation
 //will be passed into the generator backends.
 type Package struct {
@@ -55,6 +76,13 @@ type Package struct {
 	Name string
 	//Version is the version for the package contents.
 	Version string
+	//PrereleaseType specifies whether it's a an alpha, beta or a final release.
+	PrereleaseType PrereleaseType
+	//PrereleaseNo is a counter of prereleases of a given type.
+	//(PrereleaseType=alpha, PrereleaseNo=5) will append "alpha.5" to the
+	//package's version (with a separator appropriate for a given package
+	//format).
+	PrereleaseNo uint
 	//Release is a counter that can be increased when the same version of one
 	//package needs to be rebuilt. The default value shall be 1.
 	Release uint

--- a/vendor/github.com/holocm/libpackagebuild/pacman/generator.go
+++ b/vendor/github.com/holocm/libpackagebuild/pacman/generator.go
@@ -100,11 +100,21 @@ func (g *Generator) Build() ([]byte, error) {
 }
 
 func fullVersionString(pkg *build.Package) string {
-	str := fmt.Sprintf("%s-%d", pkg.Version, pkg.Release)
+	var b strings.Builder
+
 	if pkg.Epoch > 0 {
-		str = fmt.Sprintf("%d:%s", pkg.Epoch, str)
+		fmt.Fprintf(&b, "%d:", pkg.Epoch)
 	}
-	return str
+
+	b.WriteString(pkg.Version)
+
+	if pkg.PrereleaseType != build.PrereleaseTypeNone {
+		fmt.Fprintf(&b, "%s.%d", pkg.PrereleaseType.ToString(), pkg.PrereleaseNo)
+	}
+
+	fmt.Fprintf(&b, "-%d", pkg.Release)
+
+	return b.String()
 }
 
 func writePKGINFO(pkg *build.Package) error {

--- a/vendor/github.com/holocm/libpackagebuild/rpm/generator.go
+++ b/vendor/github.com/holocm/libpackagebuild/rpm/generator.go
@@ -22,6 +22,7 @@ package rpm
 
 import (
 	"fmt"
+	"strings"
 
 	build "github.com/holocm/libpackagebuild"
 )
@@ -81,10 +82,19 @@ func (g *Generator) RecommendedFileName() string {
 }
 
 func versionString(pkg *build.Package) string {
+	var b strings.Builder
+
 	if pkg.Epoch > 0 {
-		return fmt.Sprintf("%d:%s", pkg.Epoch, pkg.Version)
+		fmt.Fprintf(&b, "%d:", pkg.Epoch)
 	}
-	return pkg.Version
+
+	b.WriteString(pkg.Version)
+
+	if pkg.PrereleaseType != build.PrereleaseTypeNone {
+		fmt.Fprintf(&b, "~%s.%d", pkg.PrereleaseType.ToString(), pkg.PrereleaseNo)
+	}
+
+	return b.String()
 }
 
 func fullVersionString(pkg *build.Package) string {


### PR DESCRIPTION
The "PrereleaseType" and "PrereleaseNo" config values are incorporated
into version strings for different package formats in a way that makes
the package managers detect upgrades and downgrades correctly. Tested
with the sequence:

  1.0.0-alpha.1 < 1.0.0-alpha.3 < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0

For Debian and RPM the "prerelease" part of version is separated
from the main part with "~". It's an established convention on Debian.

Fedora has other recommendations, which, unfortunately, omit this
information from the version string. The Debian convention still works
with RPM and it's clearer to the end-user.

Pacman doesn't allow "~" in version strings. It allows "\_", but using
"\_" results in the "1.0.0-beta.11 -> 1.0.0" transition being
recognized as a downgrade. Dropping the separator altogether fixes the
issue.