### PR TITLE
fix documentation on cli argument value passing

### DIFF
--- a/doc/holo-build.8.pod
+++ b/doc/holo-build.8.pod
@@ -63,7 +63,7 @@ is read from standard input instead.
 
 =over 4
 
-=item B<--output>=I<filename>
+=item B<-o>, B<--output>=I<filename>
 
 Write the resulting package to I<filename>. If not given, write the package into
 the working directory using the naming convention for the corresponding output
@@ -71,7 +71,7 @@ package format. If I<filename> refers to a directory, write the package into thi
 directory using the naming convention for the corresponding output package format.
 If the I<filename> is C<->, write the package to standard output.
 
-=item B<--force>/B<--no-force>
+=item B<-f>, B<--force>/B<--no-force>
 
 By default, C<holo-build> will fail if the target file already exists. This
 behavior protects against the user forgetting to increase the version when
@@ -116,7 +116,7 @@ resolution).
 
 Print out usage information.
 
-=item B<--version>
+=item B<-V>, B<--version>
 
 Print out holo-build's version string.
 

--- a/doc/holo-build.8.pod
+++ b/doc/holo-build.8.pod
@@ -63,7 +63,7 @@ is read from standard input instead.
 
 =over 4
 
-=item B<--output> I<filename>
+=item B<--output>=I<filename>
 
 Write the resulting package to I<filename>. If not given, write the package into
 the working directory using the naming convention for the corresponding output
@@ -78,9 +78,9 @@ behavior protects against the user forgetting to increase the version when
 editing the package description. With C<--force>, the target file will be
 overwritten when it exists.
 
-This switch has no effect when C<--output -> or C<--suggest-filename> is in effect.
+This switch has no effect when C<--output=-> or C<--suggest-filename> is in effect.
 
-=item B<--format> I<format>
+=item B<--format>=I<format>
 
 Generate a package of the specified format, instead of the default package
 format for the current distribution. Valid values are C<debian>, C<pacman> and
@@ -130,11 +130,11 @@ These switches will be removed in the next major version.
 
 =item B<--debian>
 
-Use C<--format debian> instead.
+Use C<--format=debian> instead.
 
 =item B<--pacman>
 
-Use C<--format pacman> instead.
+Use C<--format=pacman> instead.
 
 =item B<--reproducible>
 
@@ -142,11 +142,11 @@ No effect. All packages are now built reproducibly.
 
 =item B<--rpm>
 
-Use C<--format rpm> instead.
+Use C<--format=rpm> instead.
 
 =item B<--stdout>
 
-Use C<--output -> instead.
+Use C<--output=-> instead.
 
 =back
 

--- a/src/holo-build/main.go
+++ b/src/holo-build/main.go
@@ -121,9 +121,9 @@ func parseArgs() options {
 	//TODO: remove everything that is flagged as deprecated
 	withForce := pflag.BoolP("force", "f", false, "Overwrite existing output file")
 	formatString := pflag.String("format", "", "Output file format (\"debian\", \"pacman\" or \"rpm\")")
-	formatDebian := pflag.Bool("debian", false, "Generate Debian package (deprecated, use \"--format debian\" instead)")
-	formatPacman := pflag.Bool("pacman", false, "Generate Pacman package (deprecated, use \"--format pacman\" instead)")
-	formatRPM := pflag.Bool("rpm", false, "Generate RPM package (deprecated, use \"--format rpm\" instead)")
+	formatDebian := pflag.Bool("debian", false, "Generate Debian package (deprecated, use \"--format=debian\" instead)")
+	formatPacman := pflag.Bool("pacman", false, "Generate Pacman package (deprecated, use \"--format=pacman\" instead)")
+	formatRPM := pflag.Bool("rpm", false, "Generate RPM package (deprecated, use \"--format=rpm\" instead)")
 	outputFileName := pflag.StringP("output", "o", "", "Output file name (or \"-\" for standard output)")
 	outputStdout := pflag.Bool("stdout", false, "Write package to standard output (deprecated, use \"-o -\" instead)")
 	noOutputStdout := pflag.Bool("no-stdout", false, "Revert --stdout (deprecated, use \"-o\" instead)")
@@ -135,7 +135,7 @@ func parseArgs() options {
 	pflag.Parse()
 
 	if *noOutputStdout {
-		showErrorMsg("--no-stdout is deprecated - use \"--output ''\" instead")
+		showErrorMsg("--no-stdout is deprecated - use \"--output=''\" instead")
 		*outputStdout = false
 	}
 	if *noReproducible {
@@ -154,7 +154,7 @@ func parseArgs() options {
 
 	var hasArgsError bool
 	if *outputStdout {
-		showErrorMsg("--stdout is deprecated - use \"--output -\" instead")
+		showErrorMsg("--stdout is deprecated - use \"--output=-\" instead")
 		if *outputFileName != "" {
 			showErrorMsg("--output and --stdout may not be used at the same time")
 			hasArgsError = true
@@ -164,21 +164,21 @@ func parseArgs() options {
 
 	switch {
 	case *formatDebian:
-		showErrorMsg("--debian is deprecated - use \"--format debian\" instead")
+		showErrorMsg("--debian is deprecated - use \"--format=debian\" instead")
 		if *formatString != "" {
 			showErrorMsg("--debian and --format may not be used at the same time")
 			hasArgsError = true
 		}
 		*formatString = "debian"
 	case *formatPacman:
-		showErrorMsg("--pacman is deprecated - use \"--format pacman\" instead")
+		showErrorMsg("--pacman is deprecated - use \"--format=pacman\" instead")
 		if *formatString != "" {
 			showErrorMsg("--pacman and --format may not be used at the same time")
 			hasArgsError = true
 		}
 		*formatString = "pacman"
 	case *formatRPM:
-		showErrorMsg("--rpm is deprecated - use \"--format rpm\" instead")
+		showErrorMsg("--rpm is deprecated - use \"--format=rpm\" instead")
 		if *formatString != "" {
 			showErrorMsg("--rpm and --format may not be used at the same time")
 			hasArgsError = true

--- a/test/interface/02-deprecated-cli-options/expected-stderr
+++ b/test/interface/02-deprecated-cli-options/expected-stderr
@@ -3,17 +3,17 @@ building with --reproducible
 building with --no-reproducible
 !! --no-reproducible is deprecated and can safely be removed
 building with --debian
-!! --debian is deprecated - use "--format debian" instead
+!! --debian is deprecated - use "--format=debian" instead
 building with --format=debian
 building with --rpm
-!! --rpm is deprecated - use "--format rpm" instead
+!! --rpm is deprecated - use "--format=rpm" instead
 building with --format=rpm
 building with --pacman
-!! --pacman is deprecated - use "--format pacman" instead
+!! --pacman is deprecated - use "--format=pacman" instead
 building with --format=pacman
 building with --stdout
-!! --stdout is deprecated - use "--output -" instead
+!! --stdout is deprecated - use "--output=-" instead
 building with --output=-
 building with --no-stdout
-!! --no-stdout is deprecated - use "--output ''" instead
+!! --no-stdout is deprecated - use "--output=''" instead
 building with --output=""


### PR DESCRIPTION
pflag requires a "=" between argument name and value, as per its docs:

> Command line flag syntax:
>         --flag    // boolean flags only
>         --flag=x

So passing "--output -" or "--format debian" to cli will produce an
error. "-o -" will work, because it's the short variant of the "output"
flag and pflag supports this format for those.